### PR TITLE
Convert we/our/us pronouns to I/me/my throughout

### DIFF
--- a/client/src/components/lead-magnet.tsx
+++ b/client/src/components/lead-magnet.tsx
@@ -73,7 +73,7 @@ export default function LeadMagnet({ isOpen, onClose, source = "unknown" }: Lead
     onError: (error: any) => {
       toast({
         title: "Submission Failed",
-        description: error.response?.data?.message || "Please try again or contact us directly.",
+        description: error.response?.data?.message || "Please try again or contact me directly.",
         variant: "destructive",
       });
     },
@@ -106,7 +106,7 @@ export default function LeadMagnet({ isOpen, onClose, source = "unknown" }: Lead
                 Free Reality Capture Guide
               </DialogTitle>
               <DialogDescription className="text-gray-300 text-center">
-                Download our comprehensive ROI calculator and planning guide for reality capture projects
+                Download my comprehensive ROI calculator and planning guide for reality capture projects
               </DialogDescription>
             </DialogHeader>
 

--- a/client/src/components/review-dialog.tsx
+++ b/client/src/components/review-dialog.tsx
@@ -40,8 +40,8 @@ export default function ReviewDialog({ trigger, triggerText = "Leave a Review" }
         <DialogHeader>
           <DialogTitle className="text-2xl font-bold">Share Your Experience</DialogTitle>
           <DialogDescription className="text-gray-400">
-            We'd love to hear about your experience working with Six1Five Studio.
-            Your feedback helps us improve and helps others understand the quality of our work.
+            I'd love to hear about your experience working with Six1Five Studio.
+            Your feedback helps me improve and helps others understand the quality of my work.
           </DialogDescription>
         </DialogHeader>
         <ReviewForm onSuccess={handleSuccess} />

--- a/client/src/components/review-form.tsx
+++ b/client/src/components/review-form.tsx
@@ -242,7 +242,7 @@ export default function ReviewForm({ onSuccess }: ReviewFormProps) {
       </Button>
 
       <p className="text-sm text-gray-400 text-center">
-        Your review will be published after approval by our team.
+        Your review will be published after my approval.
       </p>
     </form>
   );

--- a/client/src/components/testimonials-section.tsx
+++ b/client/src/components/testimonials-section.tsx
@@ -177,7 +177,7 @@ export default function TestimonialsSection() {
               Ready to capture your site?
             </h3>
             <p className="text-white/90 mb-6">
-              Join our satisfied clients and experience professional reality capture services.
+              Join my satisfied clients and experience professional reality capture services.
             </p>
             <button
               onClick={scrollToContact}

--- a/client/src/data/faq.json
+++ b/client/src/data/faq.json
@@ -111,7 +111,7 @@
         },
         {
           "question": "Who owns the rights to captured images and data?",
-          "answer": "Clients retain full ownership rights to all deliverable data and processed outputs upon final payment. Raw imagery and flight data are retained for backup purposes according to our data retention policy, but ownership transfers to the client."
+          "answer": "Clients retain full ownership rights to all deliverable data and processed outputs upon final payment. Raw imagery and flight data are retained for backup purposes according to my data retention policy, but ownership transfers to the client."
         },
         {
           "question": "Can you work on secure or restricted sites?",

--- a/client/src/pages/gallery.tsx
+++ b/client/src/pages/gallery.tsx
@@ -100,7 +100,7 @@ export default function Gallery() {
     <div className="min-h-screen bg-[hsl(218,11%,15%)] text-white font-sans">
       <SEOHead
         title="Portfolio Gallery - Six1Five Studio | Reality Capture Projects"
-        description="Explore our portfolio of drone mapping, LiDAR scanning, and photogrammetry projects for construction, real estate, agriculture, and historic preservation."
+        description="Explore my portfolio of drone mapping, LiDAR scanning, and photogrammetry projects for construction, real estate, agriculture, and historic preservation."
         keywords="reality capture portfolio, drone mapping projects, LiDAR scans, photogrammetry gallery, 3D model viewer, construction surveying, AEC technology"
         canonicalUrl={getCanonicalUrl('/gallery')}
         ogImage="/images/og-gallery.jpg"
@@ -115,7 +115,7 @@ export default function Gallery() {
               3D Model <span className="text-[hsl(199,89%,48%)]">Gallery</span>
             </h1>
             <p className="text-xl text-gray-400 max-w-2xl mx-auto">
-              Explore our complete collection of reality capture projects. Each model tells a story of precision, innovation, and digital transformation.
+              Explore my complete collection of reality capture projects. Each model tells a story of precision, innovation, and digital transformation.
             </p>
           </div>
 
@@ -313,7 +313,7 @@ export default function Gallery() {
           <div className="mt-16 text-center bg-gray-800 rounded-xl p-8 border border-gray-700">
             <h2 className="text-2xl font-bold mb-4">Ready to Create Your Own 3D Model?</h2>
             <p className="text-gray-400 mb-6 max-w-2xl mx-auto">
-              From concept to completion, we deliver high-quality reality capture services that bring your projects into the digital realm.
+              From concept to completion, I deliver high-quality reality capture services that bring your projects into the digital realm.
             </p>
             <Link href="/#contact">
               <Button className="bg-[hsl(24,95%,53%)] hover:bg-[hsl(24,95%,48%)] text-white px-8 py-3 rounded-lg font-semibold">

--- a/client/src/pages/pricing.tsx
+++ b/client/src/pages/pricing.tsx
@@ -107,11 +107,11 @@ const addOns = [
 const faqs = [
   {
     question: "What factors affect pricing?",
-    answer: "Pricing depends on site size, complexity, desired resolution, deliverable formats, turnaround time, and site accessibility. We provide custom quotes after reviewing your project requirements.",
+    answer: "Pricing depends on site size, complexity, desired resolution, deliverable formats, turnaround time, and site accessibility. I provide custom quotes after reviewing your project requirements.",
   },
   {
     question: "Do you offer volume discounts?",
-    answer: "Yes! We offer discounted rates for multi-site projects, ongoing monitoring programs, and long-term partnerships. Contact us to discuss volume pricing.",
+    answer: "Yes! I offer discounted rates for multi-site projects, ongoing monitoring programs, and long-term partnerships. Contact me to discuss volume pricing.",
   },
   {
     question: "What's included in the base price?",
@@ -123,11 +123,11 @@ const faqs = [
   },
   {
     question: "What if my project is outside these tiers?",
-    answer: "These are starting points. Every project is unique. Contact us with your specific requirements for a custom quote tailored to your needs.",
+    answer: "These are starting points. Every project is unique. Contact me with your specific requirements for a custom quote tailored to your needs.",
   },
   {
     question: "Do you travel for projects?",
-    answer: "Yes! We serve clients nationwide. Travel expenses may apply for projects outside our local service area (details provided in quote).",
+    answer: "Yes! I serve clients nationwide. Travel expenses may apply for projects outside my local service area (details provided in quote).",
   },
 ];
 
@@ -154,7 +154,7 @@ export default function Pricing() {
               Invest in <span className="text-[hsl(199,89%,48%)]">Precision</span>
             </h1>
             <p className="text-xl text-gray-400 max-w-2xl mx-auto">
-              Clear, competitive pricing for professional reality capture services. Choose the tier that fits your project, or contact us for a custom quote.
+              Clear, competitive pricing for professional reality capture services. Choose the tier that fits your project, or contact me for a custom quote.
             </p>
           </div>
 
@@ -166,7 +166,7 @@ export default function Pricing() {
           {/* Pricing Tiers Section */}
           <div className="text-center mb-8">
             <h2 className="text-3xl font-bold mb-2">Standard Pricing Tiers</h2>
-            <p className="text-gray-400">Or browse our standard packages below</p>
+            <p className="text-gray-400">Or browse my standard packages below</p>
           </div>
 
           {/* Pricing Cards */}
@@ -263,7 +263,7 @@ export default function Pricing() {
               <p className="text-gray-400 text-sm">
                 These are starting prices for typical projects. Every site is unique—factors like terrain complexity,
                 flight restrictions, desired accuracy, and deliverable requirements can affect final pricing.
-                <span className="text-white font-medium"> Contact us for an accurate quote</span> based on your specific needs.
+                <span className="text-white font-medium"> Contact me for an accurate quote</span> based on your specific needs.
               </p>
             </div>
           </div>
@@ -273,7 +273,7 @@ export default function Pricing() {
             <div className="text-center mb-8">
               <h2 className="text-3xl font-bold mb-4">Frequently Asked Questions</h2>
               <p className="text-gray-400 max-w-2xl mx-auto">
-                Have questions about our pricing? We've got answers.
+                Have questions about my pricing? I've got answers.
               </p>
             </div>
 
@@ -296,7 +296,7 @@ export default function Pricing() {
             </h2>
             <p className="text-gray-300 mb-6 max-w-2xl mx-auto text-lg">
               Calculate your project ROI, compare technologies, and get expert planning templates.
-              No credit card required - just instant access to our comprehensive guide.
+              No credit card required - just instant access to my comprehensive guide.
             </p>
             <LeadMagnetTrigger
               source="pricing_page"
@@ -310,7 +310,7 @@ export default function Pricing() {
           <div className="text-center bg-gray-800 rounded-xl p-8 border border-gray-700">
             <h2 className="text-2xl font-bold mb-4">Ready to Get Started?</h2>
             <p className="text-gray-400 mb-6 max-w-2xl mx-auto">
-              Tell us about your project and we'll provide a detailed quote within 24 hours.
+              Tell me about your project and I'll provide a detailed quote within 24 hours.
               No obligation, no hidden fees.
             </p>
             <div className="flex flex-col sm:flex-row gap-4 justify-center">


### PR DESCRIPTION
## Summary

22 pronoun replacements across 7 files — single-operator business voice throughout.

| File | Changes |
|------|---------|
| `client/src/data/faq.json` | "our data retention policy" → "my data retention policy" |
| `client/src/components/review-dialog.tsx` | "We'd love" → "I'd love", "helps us" → "helps me", "our work" → "my work" |
| `client/src/components/review-form.tsx` | "approval by our team" → "my approval" |
| `client/src/components/testimonials-section.tsx` | "Join our satisfied clients" → "Join my satisfied clients" |
| `client/src/components/lead-magnet.tsx` | "contact us directly" → "contact me directly", "Download our comprehensive" → "Download my comprehensive" |
| `client/src/pages/gallery.tsx` | "Explore our portfolio/collection" → "my", "we deliver" → "I deliver" |
| `client/src/pages/pricing.tsx` | 9 instances: "We provide/offer/serve", "Contact us", "our pricing/packages/guide/service area", "we'll provide" → singular equivalents |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LLMUrp7qLZgpqZXb24sZuv

---
_Generated by [Claude Code](https://claude.ai/code/session_01LLMUrp7qLZgpqZXb24sZuv)_